### PR TITLE
V1 compatibility

### DIFF
--- a/src/lib/smartLockCommands/RequestConfigCommand.ts
+++ b/src/lib/smartLockCommands/RequestConfigCommand.ts
@@ -52,8 +52,11 @@ export class RequestConfigCommand extends SmartLockCommand {
         let hardwareMinorVersion: number = payload.readUInt8(70);
         this._response.data.hardwareRevision = hardwareMajorVersion + "." + hardwareMinorVersion;
 
-        this._response.data.homeKitStatus = payload.readUInt8(71);
-        this._response.data.timeZoneId = payload.readUInt16LE(72);
+        //Additional fields added in API V2 only available on Nuki V2
+        if(majorVersion > 1) {
+          this._response.data.homeKitStatus = payload.readUInt8(71);
+          this._response.data.timeZoneId = payload.readUInt16LE(72);
+        }
 
         this._complete = true;
     }

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -7,16 +7,9 @@ export enum PairingState {
     IDLE,
     FAILED,
     REQ_PUB_KEY,
-    REQ_PUB_KEY_FIN,
     REQ_CHALLENGE,
-    REQ_CHALLENGE_FIN,
     REQ_CHALLENGE_AUTH,
-    REQ_CHALLENGE_AUTH_FIN,
-    REQ_AUTH_ID_A,
-    REQ_AUTH_ID_B,
-    REQ_AUTH_ID_C,
-    REQ_AUTH_ID_D,
-    REQ_AUTH_ID_FIN,
+    REQ_AUTH_ID,
     REQ_AUTH_ID_CONFIRM,
     PAIRED
 }


### PR DESCRIPTION
This fixes issues with the V1 lock, since it only sends 70 bytes of data. This also fixes an issue with homebridge-nubli, since it requests the config during startup.